### PR TITLE
Add points to servers with a domain name

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -1,4 +1,3 @@
-
 # Enables detailed tracebacks and an interactive Python console on errors.
 # Never use in production!
 DEBUG = False
@@ -8,7 +7,7 @@ HOST = "127.0.0.1"
 # Port for development server to listen on
 PORT = 5000
 
-# Amount of time, is seconds, after which servers are removed from the list
+# Amount of time, in seconds, after which servers are removed from the list
 # if they haven't updated their listings.  Note: By default Minetest servers
 # only announce once every 5 minutes, so this should be more than 300.
 PURGE_TIME = 350
@@ -17,12 +16,18 @@ PURGE_TIME = 350
 # e.g. ['2620:101::44']
 BANNED_IPS = []
 
-# List of banned servers as host/port pairs
-# e.g. ['1.2.3.4/30000', 'lowercase.hostname', 'lowercase.hostname/30001']
+# List of banned servers as host/port pairs, domains must be lowercase
+# e.g. ['1.2.3.4/30000', 'server.example.net', 'server.example.net/30001']
 BANNED_SERVERS = []
+
+# List of banned domain suffixes, must be lowercase
+# e.g. ['.example.net', 'server.example.com']
+BANNED_DOMAINS = []
+
+# List of domain suffixes that should not get a point bonus (e.g. free domains), must be lowercase
+IRREPUTABLE_DOMAINS = ['.cf', '.ga', '.gq', '.ml', '.tk']
 
 # Creates server entries if a server sends an 'update' and there is no entry yet.
 # This should only be used to populate the server list after list.json was deleted.
 # This WILL cause problems such as mapgen, mods and privilege information missing from the list
 ALLOW_UPDATE_WITHOUT_OLD = False
-


### PR DESCRIPTION
Rationale:
- Servers with registered domains are more likely to stick around for a while.
- Requiring a (non-free) registered domain to rank highly on the list means that servers that send falsified data can be more effectively banned or at least kept low on the list.

This also adds new options:
- banned domain suffixes: You can ban a specific domain or an entire suffix like `.bad-servers.net` so that servers can't just change subdomains, they would have to buy a new domain to evade the ban.
- "irreputable" domain suffixes that shouldn't get the extra points: free domains like `.tk` can be added to this list so that legitimate servers can still use them (albeit with a lower ranking) but servers that are trying to game the rankings will need to pay for a domain to evade bans.

A quick check of the server list showed that most of the top-ranking servers already have non-free domains, (and most of the ones that don't have domains are MultiCraft servers).  So this shouldn't change the ranking too much.