### PR TITLE
Rework domain verification a bit

### DIFF
--- a/server.py
+++ b/server.py
@@ -439,13 +439,17 @@ def asyncFinishThread(server):
 		if server["ip"] in addresses:
 			pass
 		elif (":" in server["ip"] and not have_v6) or ("." in server["ip"] and not have_v4):
+			# If the client is ipv6 and there is no ipv6 on the domain (or the inverse)
+			# then the check cannot possibly ever succeed.
+			# Because this often happens accidentally just tolerate it.
 			pass
 		else:
 			err = "Requester IP %s does not match host %s" % (server["ip"], server["address"])
 			if isDomain(server["address"]):
 				err += " (valid: %s)" % " ".join(addresses)
 			app.logger.warning(err)
-			if not isDomain(server["address"]): # temp
+			# TODO make this warning for the time being
+			if not isDomain(server["address"]):
 				errorTracker.put(getErrorPK(server), err)
 				return
 

--- a/server.py
+++ b/server.py
@@ -434,13 +434,20 @@ def asyncFinishThread(server):
 
 	if checkAddress:
 		addresses = set(data[4][0] for data in info)
-		if not server["ip"] in addresses:
+		have_v4 = any("." in s for s in addresses)
+		have_v6 = any(":" in s for s in addresses)
+		if server["ip"] in addresses:
+			pass
+		elif (":" in server["ip"] and not have_v6) or ("." in server["ip"] and not have_v4):
+			pass
+		else:
 			err = "Requester IP %s does not match host %s" % (server["ip"], server["address"])
 			if isDomain(server["address"]):
 				err += " (valid: %s)" % " ".join(addresses)
 			app.logger.warning(err)
-			errorTracker.put(getErrorPK(server), err)
-			return
+			if not isDomain(server["address"]): # temp
+				errorTracker.put(getErrorPK(server), err)
+				return
 
 	geo = geoip_lookup_continent(info[-1][4][0])
 	if geo:

--- a/server.py
+++ b/server.py
@@ -440,8 +440,8 @@ def asyncFinishThread(server):
 
 	if checkAddress:
 		addresses = set(data[4][0] for data in info)
-		have_v4 = any("." in s for s in addresses)
-		have_v6 = any(":" in s for s in addresses)
+		have_v4 = any(d[0] == socket.AF_INET for d in info)
+		have_v6 = any(d[0] == socket.AF_INET6 for d in info)
 		if server["ip"] in addresses:
 			pass
 		elif (":" in server["ip"] and not have_v6) or ("." in server["ip"] and not have_v4):


### PR DESCRIPTION
old domain verification:
* if client IP matches the server domain: all good :heavy_check_mark:
  * e.g. `1.2.3.4` announces `foo.com` which resolves to `1.2.3.4` and `2001:db8::1`
* otherwise: failure :x:

**problem**: the domain verification has been disabled in prod for a long long time since it caused too many false-positive issues
A common problem is that the announce request comes over IPv6 (these days often configured automatically), but at the same time the domain does not have an IPv6 address.
(most people don't care or have reasons for avoiding it *and* you also need `ipv6_server=true` for it to work)

new domain verification:
* if client IP matches domain: all good :heavy_check_mark:
* otherwise, if client is IPv6 and domain only has IPv4 (or inverse): silently tolerated :heavy_check_mark:
  * the problematic situation described above
* otherwise, if there is no domain name: failure :x:
  * e.g. `1.2.3.4` announces `4.5.6.7`
* otherwise: pass, but client is given a warning that this will become stricter in the future¹ :warning:
  * e.g. `1.2.3.4` announces `foo.com` which points to `1.2.3.5`

new domain verification (intended future change, next month):
* if client IP matches domain: all good :heavy_check_mark:
* otherwise, if client is IPv6 and domain only has IPv4 (or inverse): silently tolerated :heavy_check_mark:
* otherwise: failure :x:

¹: there are a bunch of big servers that accidentally fail this check. hence the grace period.