### PR TITLE
feat: Add route to fetch server information by IP and port

### DIFF
--- a/server.py
+++ b/server.py
@@ -78,6 +78,40 @@ def list_json():
 	return send_from_directory(app.static_folder, "list.json", max_age=20)
 
 
+@app.route("/server/<string:ip>/<int:port>")
+def get_server(ip, port):
+    try:
+        # Validate IP address
+        if ":" in ip:
+            # IPv6 address
+            parts = ip.split(":")
+            if len(parts) > 8:
+                raise ValueError("Invalid IPv6 address")
+            for part in parts:
+                if not part or len(part) > 4:
+                    raise ValueError("Invalid IPv6 address")
+        else:
+            # IPv4 address
+            parts = ip.split(".")
+            if len(parts) != 4:
+                raise ValueError("Invalid IPv4 address")
+            for part in parts:
+                if not part.isdigit() or not 0 <= int(part) <= 255:
+                    raise ValueError("Invalid IPv4 address")
+
+        # Validate port
+        if port < 0 or port > 65535:
+            raise ValueError("Invalid port")
+
+        server = serverList.get(ip, port)
+        if server:
+            return server
+        else:
+            return "Server not found", 404
+    except ValueError as e:
+        return str(e), 400
+
+
 @app.route("/geoip")
 def geoip():
 	continent = geoip_lookup_continent(request.remote_addr)

--- a/server.py
+++ b/server.py
@@ -81,28 +81,6 @@ def list_json():
 @app.route("/server/<string:ip>/<int:port>")
 def get_server(ip, port):
     try:
-        # Validate IP address
-        if ":" in ip:
-            # IPv6 address
-            parts = ip.split(":")
-            if len(parts) > 8:
-                raise ValueError("Invalid IPv6 address")
-            for part in parts:
-                if not part or len(part) > 4:
-                    raise ValueError("Invalid IPv6 address")
-        else:
-            # IPv4 address
-            parts = ip.split(".")
-            if len(parts) != 4:
-                raise ValueError("Invalid IPv4 address")
-            for part in parts:
-                if not part.isdigit() or not 0 <= int(part) <= 255:
-                    raise ValueError("Invalid IPv4 address")
-
-        # Validate port
-        if port < 0 or port > 65535:
-            raise ValueError("Invalid port")
-
         server = serverList.get(ip, port)
         if server:
             return server


### PR DESCRIPTION
This PR adds an API route to fetch information about a particular server as opposed to fetching the whole list. 

This will be useful for allowing server owners to add stats such as live player counters to their websites without having to load the whole server list.